### PR TITLE
Add react-query and move pagination logic to server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1408,6 +1408,11 @@
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
     },
+    "@scarf/scarf": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.0.4.tgz",
+      "integrity": "sha512-lkhjzeYyYAG4VvdrjvbZCOYzXH5vCwfzYj9xJ4zHDgyYIOzObZwcsbW6W1q5Z4tywrb14oG/tfsFAMMQPCTFqw=="
+    },
     "@sheerun/mutationobserver-shim": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.3.tgz",
@@ -11177,6 +11182,15 @@
         "warning": "^4.0.2"
       }
     },
+    "react-query": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/react-query/-/react-query-1.3.3.tgz",
+      "integrity": "sha512-hamNWxLHycMv0hYIlUK/GSQUkXiQML4sUjeqxYJ3W4FO6TLXxqTgtj/r0W7CYQ0VYGvmU3CmbaP6gESxRdkbuw==",
+      "requires": {
+        "@scarf/scarf": "^1.0.0",
+        "ts-toolbelt": "^6.4.2"
+      }
+    },
     "react-redux": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.0.tgz",
@@ -13166,6 +13180,11 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.1.6.tgz",
       "integrity": "sha512-CrG5GqAAzMT7144Cl+UIFP7mz/iIhiy+xQ6GGcnjTezhALT02uPMRw7tgDSESgB5MsfKt55+GPWw4ir1kVtMIQ=="
+    },
+    "ts-toolbelt": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-6.6.2.tgz",
+      "integrity": "sha512-P0fN4yv9rkTmKsu/Xew8heopmQ3fDnCF5tY4CV1ZMAUeBHJA6QsJhMEdxtWNdgV7dnKKAAw+A12azm2cONQ6NQ=="
     },
     "tslib": {
       "version": "1.11.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "react-datepicker": "^2.14.1",
     "react-dom": "^16.13.1",
     "react-icons": "^3.9.0",
+    "react-query": "^1.3.3",
     "react-redux": "^7.2.0",
     "react-router-dom": "^5.1.2",
     "react-scripts": "3.4.1",

--- a/src/components/Jobs/components/JobsHeader/index.js
+++ b/src/components/Jobs/components/JobsHeader/index.js
@@ -2,8 +2,6 @@ import React, { useState } from 'react';
 import Paper from '@material-ui/core/Paper';
 import TextField from '@material-ui/core/TextField';
 import { makeStyles } from '@material-ui/core/styles';
-import { getJobsBySearch } from '../../../../actions/jobPostingActions';
-import { useDispatch } from 'react-redux';
 
 const useStyles = makeStyles({
   paper: {
@@ -13,23 +11,24 @@ const useStyles = makeStyles({
   },
 });
 
-export const JobsHeader = () => {
+export const JobsHeader = ({ setQuery }) => {
   const classes = useStyles();
   const [search, setSearch] = useState('');
-  const dispatch = useDispatch();
+
   const handleSearch = (e) => {
-    if (e.key === 'Enter') {
-      dispatch(getJobsBySearch(search));
+    const trimmedValue = search.trim()
+    if (e.key === 'Enter' && trimmedValue) {
+      setQuery(trimmedValue)
     }
-    console.log(search);
   };
+
   return (
     <Paper classes={{ root: classes.paper }}>
       <TextField
         id="jobs-search"
         label="Search"
         value={search}
-        onChange={(e) => setSearch(e.target.value)}
+        onChange={e => setSearch(e.target.value)}
         onKeyDown={handleSearch}
         helperText="search by skills or time commitment"
       />

--- a/src/lib/api/getPaginatedJobsBySearch.js
+++ b/src/lib/api/getPaginatedJobsBySearch.js
@@ -1,0 +1,7 @@
+import axios from 'axios'
+
+export const getPaginatedJobsBySearch = async (_key, query, page, limit) => {
+  const querySlug = query ? query : 100
+  const { data: { message } } = await axios.get(`http://localhost:3000/dev/jobPosting/searchjobs/${querySlug}?page=${page}&limit=${limit}`)
+  return message
+}

--- a/src/lib/api/index.js
+++ b/src/lib/api/index.js
@@ -1,0 +1,1 @@
+export * from './getPaginatedJobsBySearch'

--- a/src/store.js
+++ b/src/store.js
@@ -1,4 +1,4 @@
-import { createStore, applyMiddleware, compose } from "redux";
+import { createStore, applyMiddleware } from "redux";
 import thunk from "redux-thunk";
 import rootReducer from "./reducers/rootReducer";
 import { composeWithDevTools } from "redux-devtools-extension";


### PR DESCRIPTION
Add react-query to cache and manage async data in `src/components/Jobs/index.js` and move pagination logic to the server to lighten the load on the client. See [backend pull-request](https://github.com/NEU-Skunkworks/C19_Website/pull/13)