### PR TITLE
fix: export get contributors

### DIFF
--- a/src/lib/api/index.js
+++ b/src/lib/api/index.js
@@ -1,2 +1,3 @@
+export * from './getContributors';
 export * from './getPaginatedJobsBySearch';
 export * from './postJob';


### PR DESCRIPTION
Export `getContributors` from `src/lib/api/index.js`